### PR TITLE
feat: add color border

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/olekukonko/tablewriter
 
 go 1.12
 
-require github.com/mattn/go-runewidth v0.0.10
+require (
+	github.com/jwalton/gchalk v1.3.0
+	github.com/mattn/go-runewidth v0.0.10
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,16 @@
+github.com/jwalton/gchalk v1.3.0 h1:uTfAaNexN8r0I9bioRTksuT8VGjrPs9YIXR1PQbtX/Q=
+github.com/jwalton/gchalk v1.3.0/go.mod h1:ytRlj60R9f7r53IAElbpq4lVuPOPNg2J4tJcCxtFqr8=
+github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
+github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/table_unicode.go
+++ b/table_unicode.go
@@ -1,6 +1,10 @@
 package tablewriter
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/jwalton/gchalk"
+)
 
 type UnicodeLineStyle int
 
@@ -28,6 +32,11 @@ func simpleSyms(center, row, column string) []string {
 // Note that combinations of thick and double lines are not supported.
 // Will return an error in case of unsupported combinations.
 func (t *Table) SetUnicodeHV(horizontal, vertical UnicodeLineStyle) error {
+	return t.SetUnicodeHVC(horizontal, vertical, gchalk.Ansi256(15))
+}
+
+// Set Unicode Table with Colored borders
+func (t *Table) SetUnicodeHVC(horizontal, vertical UnicodeLineStyle, color gchalk.ColorFn) error {
 	var syms string
 	switch {
 	case horizontal == Regular && vertical == Regular:
@@ -49,7 +58,7 @@ func (t *Table) SetUnicodeHV(horizontal, vertical UnicodeLineStyle) error {
 	}
 	t.syms = make([]string, 0, 11)
 	for _, sym := range []rune(syms) {
-		t.syms = append(t.syms, string(sym))
+		t.syms = append(t.syms, color(string(sym)))
 	}
 	return nil
 }


### PR DESCRIPTION
## Overview

This PR adds the ability to color the borders of the table using the `gchalk` library.

## Additional Information

I've added the support for the `gchalk` library since it supports a wider variety of colors and is also an ongoing transition in the organization as well.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes